### PR TITLE
Fix uulib example

### DIFF
--- a/examples/parser/Example.hs
+++ b/examples/parser/Example.hs
@@ -45,23 +45,23 @@ data Expr
 --           (by introducing priority levels for the operators)
 
 
--- Term -> let var = Expr in Expr
+-- Term -> let var = Expr in Expr | Add
 pExpr :: TokenParser Expr
 pExpr
   =   (\_ x _ e _ b -> Let x e b) <$> pKey "let" <*> pVarid <*> pKey "=" <*> pExpr <*> pKey "in" <*> pExpr
-  <|> pMult
+  <|> pAdd
 
--- Expr -> Factor | Factor * Expr
-pMult :: TokenParser Expr
-pMult
+-- Add -> Factor | Factor + Expr
+pAdd :: TokenParser Expr
+pAdd
   =   pFactor 
-  <|> (\l _ r -> Times l r) <$> pFactor <*> pKey "*" <*> pExpr
+  <|> (\l _ r -> Plus l r) <$> pFactor <*> pKey "+" <*> pExpr
 
 -- Factor -> Term | Term * Factor
 pFactor :: TokenParser Expr
 pFactor
   =   pTerm
-  <|> (\l _ r -> Plus l r) <$> pTerm <*> pKey "+" <*> pFactor
+  <|> (\l _ r -> Times l r) <$> pTerm <*> pKey "*" <*> pFactor
 
 -- Term -> var
 -- Term -> String
@@ -78,7 +78,7 @@ pTerm
 -- test it
 main :: IO ()
 main
-  = let res = parseTokens pExpr (tokenize "nofile" "let x = 3 in x+x")
+  = let res = parseTokens pExpr (tokenize "nofile" "let x = 3 in x*y+z")
     in case res of
          Left errs -> mapM_ putStrLn errs
          Right tree -> putStrLn $ show tree

--- a/examples/parser/Scanner.x
+++ b/examples/parser/Scanner.x
@@ -4,6 +4,7 @@
 module Scanner(tokenize) where
 
 import UU.Scanner
+import Data.Word (Word8)
 }
 
 $litChar   = [^[\" \\]]
@@ -30,6 +31,13 @@ type AlexInput = (Pos, String)
 
 alexInputPrevChar :: AlexInput -> Char
 alexInputPrevChar = error "alexInputPrevChar: there is no need to go back in the input."
+
+-- In Alex3 alexGetByte must be defined.
+alexGetByte :: AlexInput -> Maybe (Word8, AlexInput)
+alexGetByte (_, []) = Nothing
+alexGetByte (p, (c:cs))
+  = let p' = adv p c
+    in Just ((fromIntegral $ ord c), (p', cs))
 
 alexGetChar :: AlexInput -> Maybe (Char, AlexInput)
 alexGetChar (_, []) = Nothing


### PR DESCRIPTION
When I downloaded the uulib code, I couldn't compile and try the example code.
Reading it, also I found that the precedence of "*" and "+" symbols was not the standard, and it got me confused for a little.
- I modified the scanner to work with alex3
- I modified the example to use the standard precedence of the symbols, and the example line. Also changed some comments and the name of a function to make it more clear.
