### PR TITLE
Don't hide non-existent `Prelude(join)`

### DIFF
--- a/src/UU/Pretty/Basic.hs
+++ b/src/UU/Pretty/Basic.hs
@@ -15,8 +15,6 @@ module UU.Pretty.Basic ( PP (..), PP_Doc, PP_Exp
                  , fpar, spar
                  ) where
 
-import Prelude hiding (join)
-
 {- Pretty-printers and pretty-printing combinators. Version 2.0d
    Authors: S. Doaitse Swierstra and Pablo R. Azero
    Date: July, 1999


### PR DESCRIPTION
Older GHCs don't tolerate hiding non-existent identifiers
and compilation breaks. Specifically this single import
statement is the sole reason `uulib` doesn't compile with GHC 7.4
and older.

Moreover, `join` was never added to `Prelude`, even though it
was originally planned for AMP, due to technical problems. There's
no plans at this point to add `join`.
